### PR TITLE
fix: Update react peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,10 +96,10 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "@types/react": "^16.8.0",
-    "@types/react-dom": "^16.8.0",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "@types/react": "^16.x || 17.x",
+    "@types/react-dom": "^16.x || 17.x",
+    "react": "^16.x || 17.x",
+    "react-dom": "^16.x || 17.x"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
We use this package in our UI component library and we are working to fix all of our peer dependency warnings. This PR updates the peer deps for react to be of either 16 or 17 (which we are using fine).