### PR TITLE
refactor: remove defaultprops warning

### DIFF
--- a/src/SpinnerCircular.tsx
+++ b/src/SpinnerCircular.tsx
@@ -7,10 +7,10 @@ import './SpinnerCircular.css';
 export type SpinnerCircularProps = SpinnersProps & SecondaryColorSpinnerProps;
 
 const Component = ({
-  secondaryColor,
-  speed,
-  still,
-  thickness,
+  secondaryColor = secondaryColorDefaultProps.secondaryColor,
+  speed = secondaryColorDefaultProps.speed,
+  still = secondaryColorDefaultProps.still,
+  thickness = secondaryColorDefaultProps.thickness,
   ...svgProps
 }: SecondaryColorSpinnerProps) => {
   const strokeWidth = 4 * (thickness / 100);
@@ -43,7 +43,5 @@ const Component = ({
     </svg>
   );
 };
-
-Component.defaultProps = secondaryColorDefaultProps;
 
 export const SpinnerCircular = withSharedProps(Component);

--- a/src/SpinnerCircularFixed.tsx
+++ b/src/SpinnerCircularFixed.tsx
@@ -7,10 +7,10 @@ import './SpinnerCircularFixed.css';
 export type SpinnerCircularFixedProps = SpinnersProps & SecondaryColorSpinnerProps;
 
 const Component = ({
-  secondaryColor,
-  speed,
-  still,
-  thickness,
+  secondaryColor = secondaryColorDefaultProps.secondaryColor,
+  speed = secondaryColorDefaultProps.speed,
+  still = secondaryColorDefaultProps.still,
+  thickness = secondaryColorDefaultProps.thickness,
   ...svgProps
 }: SecondaryColorSpinnerProps) => {
   const strokeWidth = 4 * (thickness / 100);
@@ -43,7 +43,5 @@ const Component = ({
     </svg>
   );
 };
-
-Component.defaultProps = secondaryColorDefaultProps;
 
 export const SpinnerCircularFixed = withSharedProps(Component);

--- a/src/SpinnerCircularSplit.tsx
+++ b/src/SpinnerCircularSplit.tsx
@@ -7,10 +7,10 @@ import './SpinnerCircularSplit.css';
 export type SpinnerCircularSplitProps = SpinnersProps & SecondaryColorSpinnerProps;
 
 const Component = ({
-  secondaryColor,
-  speed,
-  still,
-  thickness,
+  secondaryColor = secondaryColorDefaultProps.secondaryColor,
+  speed = secondaryColorDefaultProps.speed,
+  still = secondaryColorDefaultProps.still,
+  thickness = secondaryColorDefaultProps.thickness,
   ...svgProps
 }: SecondaryColorSpinnerProps) => {
   const strokeWidth = 4 * (thickness / 100);
@@ -44,7 +44,5 @@ const Component = ({
     </svg>
   );
 };
-
-Component.defaultProps = secondaryColorDefaultProps;
 
 export const SpinnerCircularSplit = withSharedProps(Component);

--- a/src/SpinnerDiamond.tsx
+++ b/src/SpinnerDiamond.tsx
@@ -36,10 +36,10 @@ const coords = [
 export type SpinnerDiamondProps = SpinnersProps & SecondaryColorSpinnerProps;
 
 const Component = ({
-  secondaryColor,
-  speed,
-  still,
-  thickness,
+  secondaryColor = secondaryColorDefaultProps.secondaryColor,
+  speed = secondaryColorDefaultProps.speed,
+  still = secondaryColorDefaultProps.still,
+  thickness = secondaryColorDefaultProps.thickness,
   ...svgProps
 }: SecondaryColorSpinnerProps) => {
   const diamondStyle: CSSProperties = {
@@ -61,8 +61,6 @@ const Component = ({
     </svg>
   );
 };
-
-Component.defaultProps = secondaryColorDefaultProps;
 
 export const SpinnerRomb = withSharedProps(Component);
 export const SpinnerDiamond = withSharedProps(Component);

--- a/src/SpinnerDotted.tsx
+++ b/src/SpinnerDotted.tsx
@@ -18,9 +18,9 @@ const coords = [
 export type SpinnerDottedProps = SpinnersProps & SpinnerProps;
 
 export const Component = ({
-  speed,
-  still,
-  thickness,
+  speed = defaultProps.speed,
+  still = defaultProps.still,
+  thickness = defaultProps.thickness,
   ...svgProps
 }: SpinnerProps) => {
   const duration = 200 / speed;
@@ -59,7 +59,5 @@ export const Component = ({
     </svg>
   );
 };
-
-Component.defaultProps = defaultProps;
 
 export const SpinnerDotted = withSharedProps(Component);

--- a/src/SpinnerInfinity.tsx
+++ b/src/SpinnerInfinity.tsx
@@ -7,10 +7,10 @@ import './SpinnerInfinity.css';
 export type SpinnerInfinityProps = SpinnersProps & SecondaryColorSpinnerProps;
 
 const Component = ({
-  secondaryColor,
-  speed,
-  still,
-  thickness,
+  secondaryColor = secondaryColorDefaultProps.secondaryColor,
+  speed = secondaryColorDefaultProps.speed,
+  still = secondaryColorDefaultProps.still,
+  thickness = secondaryColorDefaultProps.thickness,
   ...svgProps
 }: SecondaryColorSpinnerProps) => {
   const strokeWidth = 7 * (thickness / 100);
@@ -40,7 +40,5 @@ const Component = ({
     </svg>
   );
 };
-
-Component.defaultProps = secondaryColorDefaultProps;
 
 export const SpinnerInfinity = withSharedProps(Component);

--- a/src/SpinnerRound.tsx
+++ b/src/SpinnerRound.tsx
@@ -7,9 +7,9 @@ import './SpinnerRound.css';
 export type SpinnerRoundProps = SpinnersProps & SpinnerProps;
 
 const Component = ({
-  speed,
-  still,
-  thickness,
+  speed = defaultProps.speed,
+  still = defaultProps.still,
+  thickness = defaultProps.thickness,
   ...svgProps
 }: SpinnerProps) => {
   const strokeWidth = 3 * (thickness / 100);
@@ -34,7 +34,5 @@ const Component = ({
     </svg>
   );
 };
-
-Component.defaultProps = defaultProps;
 
 export const SpinnerRound = withSharedProps(Component);

--- a/src/SpinnerRoundFilled.tsx
+++ b/src/SpinnerRoundFilled.tsx
@@ -23,9 +23,9 @@ const animations = [
 export type SpinnerRoundFilledProps = SpinnersProps & SpinnerProps;
 
 const Component = ({
-  speed,
-  still,
-  thickness,
+  speed = defaultProps.speed,
+  still = defaultProps.still,
+  thickness = defaultProps.thickness,
   ...svgProps
 }: SpinnerProps) => (
   <svg fill="none" {...svgProps} viewBox="0 0 66 66">
@@ -47,7 +47,5 @@ const Component = ({
     ))}
   </svg>
 );
-
-Component.defaultProps = defaultProps;
 
 export const SpinnerRoundFilled = withSharedProps(Component);

--- a/src/SpinnerRoundOutlined.tsx
+++ b/src/SpinnerRoundOutlined.tsx
@@ -21,9 +21,9 @@ const animations = [
 export type SpinnerRoundOutlinedProps = SpinnersProps & SpinnerProps;
 
 const Component = ({
-  speed,
-  still,
-  thickness,
+  speed = defaultProps.speed,
+  still = defaultProps.still,
+  thickness = defaultProps.thickness,
   ...svgProps
 }: SpinnerProps) => {
   const strokeWidth = 3 * (thickness / 100);
@@ -47,7 +47,5 @@ const Component = ({
     </svg>
   );
 };
-
-Component.defaultProps = defaultProps;
 
 export const SpinnerRoundOutlined = withSharedProps(Component);

--- a/src/withSharedProps.tsx
+++ b/src/withSharedProps.tsx
@@ -17,7 +17,11 @@ export type SpinnersProps = Partial<typeof defaultProps>;
 export const withSharedProps = <P extends SpinnersProps>(Component: ComponentType<P>) => {
   const Wrapper = (props: P) => {
     const {
-      color, enabled, size, style, ...otherProps
+      color = defaultProps.color,
+      enabled = defaultProps.enabled,
+      size = defaultProps.size,
+      style = defaultProps.style,
+      ...otherProps
     } = props;
     const componentProps = {
       ...otherProps,
@@ -33,8 +37,6 @@ export const withSharedProps = <P extends SpinnersProps>(Component: ComponentTyp
 
     return <Component {...componentProps as P} />;
   };
-
-  Wrapper.defaultProps = defaultProps;
 
   return Wrapper;
 };


### PR DESCRIPTION
Removed the `defaultProps` assignment to eliminate the deprecated warnings.

https://github.com/facebook/react/pull/16210